### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.ci/build/make/dependencies/apt.list
+++ b/.ci/build/make/dependencies/apt.list
@@ -1,5 +1,8 @@
 ghostscript
 git
-python-pygments
+make
+python-pip
+texlive
 texlive-font-utils
 texlive-generic-extra
+texlive-latex-extra

--- a/.ci/build/make/dependencies/python.list
+++ b/.ci/build/make/dependencies/python.list
@@ -1,0 +1,1 @@
+pygments

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,8 @@ jobs:
           name: install dependencies
           command: |
             apt update && apt install --no-install-recommends --yes \
-                    $(cat .circleci/dependencies.list)
+                    $(cat .ci/build/make/dependencies/apt.list)
+            pip install --requirement .ci/build/make/dependencies/python.list
 
       - run:
           name: build packages

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,24 @@
+name: build
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  make:
+    runs-on: ubuntu-latest
+    container: sunslayer/latex-docker:buster
+    steps:
+      - name: Install Git
+        run: |
+          apt update && apt install --no-install-recommends --yes \
+              ca-certificates \
+              git
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          apt update && apt install --no-install-recommends --yes \
+              $(cat .ci/build/make/dependencies/apt.list)
+          pip install --requirement .ci/build/make/dependencies/python.list
+      - name: make
+        run: make


### PR DESCRIPTION
This change adds a CI workflow for GitHub Actions. This workflow
essentially duplicate the existing CI workflow that uses CircleCI, but
GitHub Actions provides features not available from CircleCI, such as
executing jobs concurrently.

All the CI configuration that is currently common to CircleCI and
GitHub Actions is stored in .ci/. Doing so eliminates the need to
duplicate changes (e.g., dependencies for jobs) across multiple files.

GitHub Actions: https://github.com/features/actions