### PR TITLE
Create CTAN distribution archives for packages

### DIFF
--- a/.ci/build/make/dependencies/apt.list
+++ b/.ci/build/make/dependencies/apt.list
@@ -6,3 +6,5 @@ texlive
 texlive-font-utils
 texlive-generic-extra
 texlive-latex-extra
+unzip
+zip

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ _minted-*
 # derivative files generated via .ins and .dtx
 *.cls
 *.sty
+
+# package distribution archive
+*.zip

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ default: $(packages)
 
 .PHONY: $(packages)
 $(packages):
-	$(MAKE) -C $@
+	$(MAKE) -C $@ dist distcheck


### PR DESCRIPTION
This change creates a distribution archive for each package when
`make` is executed in the root directory of the repository. The
distribution archive for each packages comprises its documented LaTeX
(.dtx), installer (.ins), and documentation.

For distribution, CTAN prescribes the structure of packages. In
particular, all files should be inside a directory that is inside a
ZIP archive. That is, the contents of the distribution archive should
be as follows:

  my-package.zip:
    my-package/
      README
      my-package.dtx
      my-package.ins
      my-package.pdf

This change follows that recommendation.

CTAN instructions: https://ctan.org/help/upload-pkg