### PR TITLE
Archive packages following build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,3 +22,9 @@ jobs:
           pip install --requirement .ci/build/make/dependencies/python.list
       - name: make
         run: make
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: packages
+          path: |
+            **/*.zip


### PR DESCRIPTION
This change uses the GitHub Actions upload-artifact to archive all the
distribution packages created by the build workflow.