### PR TITLE
Remove documentation dependency on packages

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -40,13 +40,16 @@ while ( grep -q '^LaTeX Warning: Label(s) may have changed' $*.log ) do \
 done
 endef
 
-DEPENDENCIES = $(wildcard *.cls) $(wildcard *.sty) \
-               $(wildcard $(CWD)glossary.tex) $(wildcard $(CWD)references.bib)
+DEPENDENCIES = $(wildcard *.bib) $(wildcard $(CWD)references.bib) \
+               $(wildcard $(CWD)glossary.tex)
+
+PACKAGES = $(wildcard *.cls) $(wildcard *.sty)
 
 %.pdf: %.dtx $(DEPENDENCIES) .version.tex
 	$(compile-doc)
 
-%.pdf: %.tex $(DEPENDENCIES) $(shell find . -mindepth 2 -name "*.tex")
+%.pdf: %.tex $(DEPENDENCIES) $(PACKAGES) \
+       $(shell find . -mindepth 2 -name "*.tex")
 	$(compile-doc)
 
 %.sty: %.ins %.dtx


### PR DESCRIPTION
This change removes the dependency on class (`*.cls`) and style
(`*.sty`) files in the same directory for package documentation.
Removing the dependency prevents recompiling the documentation for all
the packages in a bundle (when there are multiple documented TeX
(`*.dtx`) files in the same directory) when any one of those package
changes.