### PR TITLE
Use consistent rule for building packages

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -54,8 +54,16 @@ PACKAGES = $(wildcard *.cls) $(wildcard *.sty)
        $(shell find . -mindepth 2 -name "*.tex")
 	$(compile-doc)
 
+%.sty: directory = $(dir $<)
 %.sty: %.ins %.dtx
-	$(TEX) -draftmode $<
+	$(TEX) -draftmode -output-directory=$(directory) $<
+
+# include packages in the search path
+packages != $(MAKE) --directory=$(CWD) --quiet list 2> /dev/null
+
+vpath %.ins $(CWD):$(addprefix $(CWD)/,$(packages))
+vpath %.dtx $(CWD):$(addprefix $(CWD)/,$(packages))
+vpath %.sty $(CWD):$(addprefix $(CWD)/,$(packages))
 
 
 derivatives += *.acn *.acr *.alg *.aux *.bbl *.blg *.dvi *.glb *.glx *.glg *.glo *.gls *.idx *.ind *.ilg *.ist *.log *.lof *.lot *.nav *.out *.pyg *.snm *.toc *.vrb

--- a/beamer/themes/theme/seas.virginia.edu/Makefile
+++ b/beamer/themes/theme/seas.virginia.edu/Makefile
@@ -1,16 +1,12 @@
 .PHONY: default
-default: beamerthemeseas.virginia.edu.sty example.pdf beamerthemeseas.virginia.edu.pdf
+default: beamerthemeseas.virginia.edu.sty beamerthemeseas.virginia.edu.pdf
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-beamerthemeseas.virginia.edu.sty: | beamercolorthemewahoo.sty
-beamerthemeseas.virginia.edu.pdf: beamerthemeseas.virginia.edu.sty example.pdf | minted
+beamerthemeseas.virginia.edu.sty:
+beamerthemeseas.virginia.edu.pdf: beamercolorthemewahoo.sty beamerthemeseas.virginia.edu.sty example.pdf | minted
 
 example.pdf: beamerthemeseas.virginia.edu.sty
 
 include $(shell git rev-parse --show-toplevel)/Makefile.mk
-
-# fall-back for Beamer themes
-beamercolorthemewahoo.sty:
-	$(MAKE) --directory=../../color/wahoo $@


### PR DESCRIPTION
This change removes the order-only prerequisites used to build other
packages (in this repository) in favor of "normal" prerequisites.